### PR TITLE
Add OpenAPI 3.0 documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,8 @@ plugins {
     id 'jacoco'     // Test Coverage Report
     id 'java'
     id 'org.springframework.boot' version '2.3.3.RELEASE'
-    // https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-gradle/
     id 'org.sonarqube' version '3.0'    // Code Quality and Security
-    // Lombok
-    id "io.freefair.lombok" version "5.3.0"
+    id 'io.freefair.lombok' version '5.3.0' // Lombok
 }
 
 // apply plugin: 'idea'     // not needed for now
@@ -17,6 +15,7 @@ targetCompatibility = 11
 
 repositories {
     mavenCentral()
+    jcenter()
 }
 
 googleJavaFormat {
@@ -46,38 +45,28 @@ sonarqube {
         property 'sonar.links.scm', 'https://github.com/URLY-WebEngineering/UrlShortener'
         property 'sonar.links.issue', 'https://github.com/URLY-WebEngineering/UrlShortener/issues'
 
-        // Code Configuration Parameters (not needed because these values are configured by default)
-        // property 'sonar.sources', 'src/main'
-        // property 'sonar.tests', 'src/test'
-        // property 'sonar.exclusions', 'src/main/resources/**/*'
-        // Code Configuration Parameters for compiled classes
-        // property 'sonar.java.binaries', 'build/classes/java/main'
-        // property 'sonar.java.test.binaries', 'build/classes/java/test'
-
         // Test Coverage Configuration Parameters
         property 'sonar.coverage.jacoco.xmlReportPaths', "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml"
     }
 }
 
-
 // Documentation for types of dependencies: https://tomgregory.com/gradle-implementation-vs-compile-dependencies/
 dependencies {
+    implementation 'commons-validator:commons-validator:1.6'
+    implementation 'com.google.guava:guava:28.1-jre'
+    implementation 'com.jayway.jsonpath:json-path:2.4.0'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
-    implementation 'commons-validator:commons-validator:1.6'
-    implementation 'com.google.guava:guava:28.1-jre'
-
-    implementation 'com.jayway.jsonpath:json-path:2.4.0'
-
-    runtime 'org.webjars:bootstrap:3.3.5'
-    runtime 'org.webjars:jquery:2.1.4'
+    compile 'com.google.zxing:core:3.3.0'
+    compile 'com.google.zxing:javase:3.3.0'
+    compile 'org.springdoc:springdoc-openapi-ui:1.5.0'
 
     runtime 'org.hsqldb:hsqldb'
-
-    compile "com.google.zxing:core:3.3.0"
-    compile 'com.google.zxing:javase:3.3.0'
+    runtime 'org.webjars:bootstrap:3.3.5'
+    runtime 'org.webjars:jquery:2.1.4'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.apache.httpcomponents:httpclient'

--- a/src/main/java/urlshortener/web/QRController.java
+++ b/src/main/java/urlshortener/web/QRController.java
@@ -1,18 +1,22 @@
 package urlshortener.web;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.net.URI;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import urlshortener.domain.ShortURL;
 import urlshortener.service.QRService;
 import urlshortener.service.ShortURLService;
 
-@Controller
+@RestController
 public class QRController {
 
   private final ShortURLService shortUrlService;
@@ -21,11 +25,22 @@ public class QRController {
     this.shortUrlService = shortUrlService;
   }
 
-  @RequestMapping(
-      value = "/qr/{id:(?!link|index).*}",
-      method = RequestMethod.GET,
-      produces = MediaType.IMAGE_PNG_VALUE)
-  public ResponseEntity<?> generateQR(@PathVariable String id, HttpServletRequest request)
+  @Operation(summary = "Generates a QR code for the shortened URL")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "201",
+            description = "QR created",
+            content = @Content(mediaType = "image/png")),
+        @ApiResponse(
+            responseCode = "404",
+            description = "id of shortened URL not found",
+            content = @Content(mediaType = "application/json"))
+      })
+  @GetMapping(value = "/qr/{id:(?!link|index).*}", produces = MediaType.IMAGE_PNG_VALUE)
+  public ResponseEntity<?> generateQR(
+      @Parameter(description = "id of the shortened url") @PathVariable String id,
+      HttpServletRequest request)
       throws Exception {
     try {
       HttpHeaders h = new HttpHeaders(); // NOSONAR

--- a/src/main/java/urlshortener/web/UrlShortenerController.java
+++ b/src/main/java/urlshortener/web/UrlShortenerController.java
@@ -85,7 +85,7 @@ public class UrlShortenerController {
       })
   @PostMapping(value = "/link")
   public ResponseEntity<ShortURL> shortener(
-      @RequestParam("url") String url,
+      @Parameter(description = "long url to shorten") @RequestParam("url") String url,
       @RequestParam(value = "sponsor", required = false) String sponsor,
       HttpServletRequest request) {
     switch (checkStatus(url)) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,8 @@ spring.datasource.password=
 spring.datasource.driverClassName=org.hsqldb.jdbcDriver
 
 server.error.include-message=always
+
+# OpenAPI 3.0 using Springdoc
+springdoc.api-docs.path=/openapi
+# springdoc.show-actuator=false # in case we want to show the actuator endpoints
+


### PR DESCRIPTION
Added OpenAPI 3.0 documentation using the [Springdoc](https://springdoc.org/) library.

Now, there is three new endpoints:
- /openapi - endpoint with the OpenAPI 3.0 description in JSON
- /openapi.yaml - endpoint with the OpenAPI 3.0 description in YAML
- /swagger-ui.html - endpoint for visualizing OpenAPI 3.0 through a UI

Information about references and how to document the new controllers has been added to the wiki.