### PR TITLE
HotFix: GoogleJavaFormat

### DIFF
--- a/src/main/java/urlshortener/service/URLStatusService.java
+++ b/src/main/java/urlshortener/service/URLStatusService.java
@@ -17,7 +17,6 @@ import urlshortener.domain.safebrowsing.SBRequest;
 import urlshortener.domain.safebrowsing.SBThreatEntry;
 import urlshortener.domain.safebrowsing.SBThreatInfo;
 import urlshortener.repository.ShortURLRepository;
-import urlshortener.repository.impl.ShortURLRepositoryImpl;
 
 @Service
 public class URLStatusService {


### PR DESCRIPTION
Fixed Google Java Format. The problem was a that Google Java Format was not being run by Travis before my last PR, when I activated it, but obviously code already in master was not being tested against the Google Java Coding Standards.